### PR TITLE
compile contracts by default before generating documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,18 @@ docgen: {
 }
 ```
 
-The `path` directory will be created if it does not exist.
-
-The `clear` option is set to `false` by default because it represents a destructive action, but should be set to `true` in most cases.
-
-The included Hardhat task may be run manually; however, it is imperative that the `compile` task be run at least once after plugin installation to ensure that the correct compiler options are set:
+The included Hardhat task may be run manually:
 
 ```bash
 yarn run hardhat docgen
 ```
+
+By default, the hardhat `compile` task is run before generating documentation.  This behavior can be disabled with the `--no-compile` flag:
+
+```bash
+yarn run hardhat docgen --no-compile
+```
+
+The `path` directory will be created if it does not exist.
+
+The `clear` option is set to `false` by default because it represents a destructive action, but should be set to `true` in most cases.

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -2,7 +2,9 @@ const {
   TASK_COMPILE,
 } = require('hardhat/builtin-tasks/task-names');
 
-task(TASK_COMPILE, async function (args, hre, runSuper) {
+task(TASK_COMPILE).addFlag(
+  'noDocgen', 'Don\'t generate documentation after running this task, even if runOnCompile option is enabled'
+).setAction(async function (args, hre, runSuper) {
   for (let compiler of hre.config.solidity.compilers) {
     compiler.settings.outputSelection['*']['*'].push('devdoc');
     compiler.settings.outputSelection['*']['*'].push('userdoc');
@@ -10,7 +12,7 @@ task(TASK_COMPILE, async function (args, hre, runSuper) {
 
   await runSuper();
 
-  if (hre.config.docgen.runOnCompile) {
-    await hre.run('docgen');
+  if (hre.config.docgen.runOnCompile && !args.noDocgen) {
+    await hre.run('docgen', { noCompile: true });
   }
 });

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -13,6 +13,7 @@ task(TASK_COMPILE).addFlag(
   await runSuper();
 
   if (hre.config.docgen.runOnCompile && !args.noDocgen) {
+    // Disable compile to avoid an infinite loop
     await hre.run('docgen', { noCompile: true });
   }
 });

--- a/tasks/docgen.js
+++ b/tasks/docgen.js
@@ -2,10 +2,21 @@ const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const { HardhatPluginError } = require('hardhat/plugins');
+const {
+  TASK_COMPILE,
+} = require('hardhat/builtin-tasks/task-names');
 
 const webpackConfig = require('../webpack.config.js');
 
-task('docgen', 'Generate NatSpec documentation automatically on compilation', async function (args, hre) {
+task(
+  'docgen', 'Generate NatSpec documentation automatically on compilation'
+).addFlag(
+  'noCompile', 'Don\'t compile before running this task'
+).setAction(async function (args, hre) {
+  if (!args.noCompile) {
+    await hre.run(TASK_COMPILE, { noDocgen: true });
+  }
+
   const config = hre.config.docgen;
 
   const output = {};


### PR DESCRIPTION
Impose behavior similar to that of https://github.com/ItsNickBarry/hardhat-contract-sizer/pull/13.